### PR TITLE
#67: fix table.CAPM beta bull / bear failing when all values for Rb…

### DIFF
--- a/R/CAPM.beta.R
+++ b/R/CAPM.beta.R
@@ -159,7 +159,13 @@ function (Ra, Rb, Rf = 0)
     xRb = Return.excess(Rb, Rf)
 
     pairs = expand.grid(1:Ra.ncols, 1:Rb.ncols)
-
+    
+    # patch: .beta fails if subset contains no positive values, !sum(Rb > 0) is true
+    if (!sum(xRb > 0)) {
+        message("Function CAPM.beta.bull: Cannot perform lm. All Rb values are negative.")
+        return(NA)
+    }
+    
     result = apply(pairs, 1, FUN = function(n, xRa, xRb)
         .beta(xRa[,n[1]], xRb[,n[2]], xRb[,n[2]] > 0), xRa = xRa, xRb = xRb)
 
@@ -204,7 +210,13 @@ function (Ra, Rb, Rf = 0)
     xRb = Return.excess(Rb, Rf)
 
     pairs = expand.grid(1:Ra.ncols, 1:Rb.ncols)
-
+    
+    # patch: .beta fails if subset contains no negative values, !sum(Rb < 0) is true
+    if (!sum(xRb < 0)) {
+        message("Function CAPM.beta.bear: Cannot perform lm. All Rb values are positive.")
+        return(NA)
+    }
+    
     result = apply(pairs, 1, FUN = function(n, xRa, xRb)
         .beta(xRa[,n[1]], xRb[,n[2]], xRb[,n[2]] < 0), xRa = xRa, xRb = xRb)
 


### PR DESCRIPTION
…are negative / positive, respectively

The main goal of this fix is to prevent failure of the `CAPM.table` function when it's individual parts have errors. The pull request implements two minor patches to fix `CAPM.beta.bear` and `CAPM.beta.bull` so the functions return `NA` and a warning message (rather than an error) when no positive or negative values, respectively, are present in the Rb subset within the linear model within the `.beta` function. As a result, the user that implements `CAPM.table` will get the desired table output with an `NA` in the results if `CAPM.beta.bull` or `CAPM.beta.bear` functions fail.