### PR TITLE
Allow single-period return calc by manually specifying periodicity

### DIFF
--- a/R/Return.portfolio.R
+++ b/R/Return.portfolio.R
@@ -156,8 +156,8 @@ Return.portfolio <- Return.rebalancing <- function(R,
   rebalance_on = rebalance_on[1]
   
   # find the right unit to subtract from the first return date to create a start date
-  extras <- list(...)
-  if (is.null(extras$freq)) freq = periodicity(R) else freq = list(scale=extras$freq)
+  dots <- list(...)
+  if (is.null(dots$freq)) freq = periodicity(R) else freq = list(scale=dots$freq)
   switch(freq$scale, 
          seconds = { stop("Use a returns series of daily frequency or higher.") },
          minute = { stop("Use a returns series of daily frequency or higher.") },

--- a/R/Return.portfolio.R
+++ b/R/Return.portfolio.R
@@ -156,7 +156,8 @@ Return.portfolio <- Return.rebalancing <- function(R,
   rebalance_on = rebalance_on[1]
   
   # find the right unit to subtract from the first return date to create a start date
-  freq = periodicity(R)
+  extras <- list(...)
+  if (is.null(extras$freq)) freq = periodicity(R) else freq = list(scale=extras$freq)
   switch(freq$scale, 
          seconds = { stop("Use a returns series of daily frequency or higher.") },
          minute = { stop("Use a returns series of daily frequency or higher.") },


### PR DESCRIPTION
There is in principle no reason why Return.portfolio() should not work for a single period.  The single-period return is simply the weighted return of the assets for the period.   However, currently Return.portfolio() fails when calculation has a single period.  The reason is that xts::periodicity fails for a single period.  This patch allows user to manually specify freq="xxx".  This allows Return.portfolio() to work for a single period.  Default behavior is unchanged.

Example:  Return.portfolio(R, freq='monthly')

Where R is an xts object of asset returns for one period.