### PR TITLE
fix clean.boudt for multivariate data

### DIFF
--- a/R/Return.clean.R
+++ b/R/Return.clean.R
@@ -212,7 +212,7 @@ function(R, alpha=.01 , trim=1e-3)
    T=dim(R)[1]; date=c(1:T)
    N=dim(R)[2];
    MCD = robustbase::covMcd(as.matrix(R),alpha=1-alpha)
-   mu = as.matrix(MCD$raw.center) #no reweighting
+   mu = as.numeric(MCD$raw.center) #no reweighting
    sigma = MCD$raw.cov
    invSigma = try(solve(sigma), silent=TRUE)
    vd2t = c();


### PR DESCRIPTION
Calling clean.boudt gives the error of non-conformable arrays shown below. This is due to mu being a column vector and R[t,] a row vector. This error occurs only when calling clean.boudt with a multivariate returns object (xts, matrix,…). Inside VaR and similar functions, clean.boudt is called via Return.clean which calls clean.boudt on each column of the data separately. For univariate series, clean.boudt performs as expected.

edhec(data)
test1 <- Return.clean(edhec, method = "boudt")
test2 <- clean.boudt(edhec)
	Error in `-.default`(R[t, ], mu) : non-conformable arrays 
test3 <- clean.boudt(edhec[, 1])

A simple solution is to replace as.matrix(MCD$raw.center) by as.numeric(MCD$raw.center), eliminating the clash between row and column vector. This has no further impact on any of the methods calling clean.boudt.

data(edhec)
test1 <- Return.clean(edhec, method = "boudt")
test2 <- clean.boudt(edhec)
test3 <- clean.boudt(as.matrix(edhec))
test4 <- clean.boudt(edhec[, 1])