### PR TITLE
Fixed subsetting by names, issue #110

### DIFF
--- a/R/Return.portfolio.R
+++ b/R/Return.portfolio.R
@@ -191,13 +191,15 @@ Return.portfolio <- Return.rebalancing <- function(R,
     # make sure that frequency(weights)<frequency(R) ?
     
     # make sure the number of assets in R matches the number of assets in weights
-    # Should we also check the names of R and names of weights?
+    # We also check the names of R and names of weights
     if(NCOL(R) != NCOL(weights)){
-      if(NCOL(R) > NCOL(weights)){
+      if(NCOL(weights)>NCOL(R)){
+        stop("number of assets is greater than number of columns in returns object")
+      } else if(length(intersect(colnames(R), colnames(weights)))!=0){
+        R = R[ , intersect(colnames(R), colnames(weights))]
+      } else{
         R = R[, 1:NCOL(weights)]
         warning("number of assets in beginning_weights is less than number of columns in returns, so subsetting returns.")
-      } else {
-        stop("number of assets is greater than number of columns in returns object")
       }
     }
   } # we should have good weights objects at this point

--- a/R/Return.portfolio.R
+++ b/R/Return.portfolio.R
@@ -195,8 +195,10 @@ Return.portfolio <- Return.rebalancing <- function(R,
     if(NCOL(R) != NCOL(weights)){
       if(NCOL(weights)>NCOL(R)){
         stop("number of assets is greater than number of columns in returns object")
-      } else if(length(intersect(colnames(R), colnames(weights)))!=0){
-        R = R[ , intersect(colnames(R), colnames(weights))]
+      } else if(is.matrix(weights)&&length(intersect(names(R), colnames(weights)))!=0){
+        R = R[ , intersect(names(R), colnames(weights))]
+      } else if(!is.matrix(weights)&&length(intersect(names(R), names(weights)))!=0){
+        R = R[ , intersect(names(R), names(weights))]
       } else{
         R = R[, 1:NCOL(weights)]
         warning("number of assets in beginning_weights is less than number of columns in returns, so subsetting returns.")

--- a/R/Return.portfolio.R
+++ b/R/Return.portfolio.R
@@ -199,7 +199,7 @@ Return.portfolio <- Return.rebalancing <- function(R,
         R = R[ , intersect(names(R), colnames(weights))]
       } else if(!is.matrix(weights)&&length(intersect(names(R), names(weights)))!=0){
         R = R[ , intersect(names(R), names(weights))]
-      } else{
+      } else {
         R = R[, 1:NCOL(weights)]
         warning("number of assets in beginning_weights is less than number of columns in returns, so subsetting returns.")
       }


### PR DESCRIPTION
If there are columns which are present in both asset returns and weights, then we subset by name. 
length(intersect(colnames(R), colnames(weights)) is needed since intersect(colnames(R), colnames(weights)) would either return a NULL or a character(0) if no columns match. character(0) can be used in an if statement by checking its length (which is 0) and this also works for NULL values(since their length are also 0).