### PR TITLE
Fixing error in legend(): border.col, border.lwd and border.lty which were confused with box.[...]

### DIFF
--- a/R/legend.R
+++ b/R/legend.R
@@ -45,8 +45,8 @@
 #' values are \code{"o"} (the default) and \code{"n"}.
 #' @param bg the background color for the legend box.  (Note that this is only
 #' used if \code{bty != "n"}.)
-#' @param box.lty,box.lwd the line type and width for the legend box.
-#' @param border.lty,border.lwd the line type and width for the legend border.
+#' @param box.col,box.lty,box.lwd the color, line type and width for the legend box.
+#' @param border.col,border.lty,border.lwd the color, line type and width for the legend border.
 #' @param pt.bg the background color for the \code{\link{points}},
 #' corresponding to its argument \code{bg}.
 #' @param cex character expansion factor \bold{relative} to current

--- a/R/legend.R
+++ b/R/legend.R
@@ -142,7 +142,7 @@ function (x, y = NULL, legend, fill = NULL, col = par("col"),
     else nx <- 0
     xlog <- par("xlog")
     ylog <- par("ylog")
-    rect2 <- function(left, top, dx, dy, density = NULL, angle, border = border.col, lty = border.lty, lwd = border.lwd, ...) {
+    rect2 <- function(left, top, dx, dy, density = NULL, angle, border = box.col, lty = box.lty, lwd = box.lwd, ...) {
         r <- left + dx
         if (xlog) {
             left <- 10^left
@@ -289,7 +289,7 @@ function (x, y = NULL, legend, fill = NULL, col = par("col"),
         if (trace)
             catn("  rect2(", left, ",", top, ", w=", w, ", h=",
                 h, ", ...)", sep = "")
-        rect2(left, top, dx = w, dy = h, col = bg, density = NULL, border = border.col)#added border = border.col
+        rect2(left, top, dx = w, dy = h, col = bg, density = NULL, border = box.col)
     }
     xt <- left + xchar + xextra + (w0 * rep.int(0:(ncol - 1),
         rep.int(n.legpercol, ncol)))[1:n.leg]
@@ -300,7 +300,7 @@ function (x, y = NULL, legend, fill = NULL, col = par("col"),
             fill <- rep(fill, length.out = n.leg)
             rect2(left = xt, top = yt + ybox/2, dx = xbox, dy = ybox,
                 col = fill, density = density, angle = angle,
-                border = box.col) #removed internal border
+                border = border.col, lty = border.lty, lwd = border.lwd) 
         }
         xt <- xt + dx.fill
     }


### PR DESCRIPTION
Today I came across this amazing package which fit the needs of a colleague who wanted to have a little special on here base plot legend. Thanks to the authors and contributors for their hard work!
However we were confused how border.col worked, because it acutally didn't. Here is a snippet of code which describes what I mean: 

```
plot(1)
PerformanceAnalytics::legend("bottomright", legend = "test", fill = "lightgrey", 
                             border.col = "blue", border.lty = "dashed", border.lwd = 2,
                             box.col = "red", box.lty = "dotted", box.lwd = 0.5)
```
Normally, the box of the legend should be red, not blue. Same with the lwd and the lty. 

I found the lines and fixed it with two commits. 
Would appreciate seeing it merged. 
If I missed something, feel free to comment. 