### PR TITLE
Fixing pass through arguments in chart.Correlation

### DIFF
--- a/R/chart.Correlation.R
+++ b/R/chart.Correlation.R
@@ -1,12 +1,12 @@
 
 
 #' correlation matrix chart
-#' 
+#'
 #' Visualization of a Correlation Matrix. On top the (absolute) value of the
 #' correlation plus the result of the cor.test as stars. On bottom, the
 #' bivariate scatterplots, with a fitted line
-#' 
-#' 
+#'
+#'
 #' @param R data for the x axis, can take matrix,vector, or timeseries
 #' @param histogram TRUE/FALSE whether or not to display a histogram
 #' @param method a character string indicating which correlation coefficient
@@ -18,10 +18,10 @@
 #' @seealso \code{\link{table.Correlation}}
 ###keywords ts multivariate distribution models hplot
 #' @examples
-#' 
+#'
 #' data(managers)
 #' chart.Correlation(managers[,1:8], histogram=TRUE, pch="+")
-#' 
+#'
 #' @export
 chart.Correlation <-
 function (R, histogram = TRUE, method=c("pearson", "kendall", "spearman"), ...)
@@ -32,7 +32,7 @@ function (R, histogram = TRUE, method=c("pearson", "kendall", "spearman"), ...)
     # bivariate scatterplots, with a fitted line
 
     x = checkData(R, method="matrix")
-    
+
     if(missing(method)) method=method[1] #only use one
     cormeth <- method
 
@@ -58,12 +58,12 @@ function (R, histogram = TRUE, method=c("pearson", "kendall", "spearman"), ...)
     f <- function(t) {
         dnorm(t, mean=mean(x), sd=sd.xts(x) )
     }
-    
+
     #remove method from dotargs
     dotargs <- list(...)
     dotargs$method <- NULL
     rm(method)
-    
+
     hist.panel = function (x, ...=NULL ) {
         par(new = TRUE)
         hist(x,
@@ -78,12 +78,12 @@ function (R, histogram = TRUE, method=c("pearson", "kendall", "spearman"), ...)
         #lines(f, col="blue", lwd=1, lty=1) how to add gaussian normal overlay?
         rug(x)
     }
-    
+
     # Draw the chart
     if(histogram)
-        pairs(x, gap=0, lower.panel=panel.smooth, upper.panel=panel.cor, diag.panel=hist.panel)
+        pairs(x, gap=0, lower.panel=panel.smooth, upper.panel=panel.cor, diag.panel=hist.panel, ...)
     else
-        pairs(x, gap=0, lower.panel=panel.smooth, upper.panel=panel.cor) 
+        pairs(x, gap=0, lower.panel=panel.smooth, upper.panel=panel.cor, ...)
 }
 
 ###############################################################################


### PR DESCRIPTION
First of all, thanks for the package. I used it for some of my work and I noticed a small bug in the chart.Correlation. It seems the pass-through arguments "..." were missing in the "pairs" function. I added that to this pull request.