### PR TITLE
Pass '...' through to `chart.TimeSeries()` functions

### DIFF
--- a/R/chart.TimeSeries.base.R
+++ b/R/chart.TimeSeries.base.R
@@ -81,7 +81,8 @@ chart.TimeSeries.base <-
                                       grid.color=grid.color, 
                                       grid.lty=grid.lty, 
                                       xaxis.labels=xaxis.labels,
-                                      yaxis.pct=yaxis.pct)
+                                      yaxis.pct=yaxis.pct,
+                                      ...)
              return(p)
            },
            ggplot2 = {

--- a/R/chart.TimeSeries.builtin.R
+++ b/R/chart.TimeSeries.builtin.R
@@ -37,7 +37,8 @@ chart.TimeSeries.builtin <-
            grid.color, 
            grid.lty, 
            xaxis.labels,
-           yaxis.pct){
+           yaxis.pct,
+           ...){
     
     y = checkData(R,method='xts')
     
@@ -100,7 +101,8 @@ chart.TimeSeries.builtin <-
                   yaxis.left = yaxis.left, 
                   yaxis.right = yaxis.right, 
                   grid.col = grid.color, 
-                  legend.loc = NULL)
+                  legend.loc = NULL,
+                  ...)
     
     if(!is.null(event.lines)) {
       

--- a/man/chart.TimeSeries.Rd
+++ b/man/chart.TimeSeries.Rd
@@ -135,7 +135,8 @@ chart.TimeSeries.builtin(
   grid.color,
   grid.lty,
   xaxis.labels,
-  yaxis.pct
+  yaxis.pct,
+  ...
 )
 
 chart.TimeSeries.dygraph(R)


### PR DESCRIPTION
This allows users to provide arguments to `plot.xts()` that aren't explicit arguments to the `chart.TimeSeries()` functions.

For example, it allows users to remove the dates from the top right of the plot:

```
set.seed(21)
returns <- xts(rnorm(100, 0, 0.005), .Date(1:100))
chart.CumReturns(returns, main.timespan = FALSE)
```

This doesn't work with the current code, but does with this patch.